### PR TITLE
Share underlying http client to cache DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TBD: Notifications
 * Look at having two log files (Warn+ and Info/Debug)
 * Add a message archiving capability
 * Unit tests
-* Check to see if InfluxClient can be shared across threads
+* ~~Check to see if InfluxClient can be shared across threads~~
 * Check on what provides altitude and if it is getting lost somehow
 * ~~Debug why seawater temperature is jacked up~~
 * Ensure MQTT Disconnect / Reconnect / Errors work

--- a/internal/BLETempHandler.go
+++ b/internal/BLETempHandler.go
@@ -67,15 +67,8 @@ func handleBLETemperatureMessage(client MQTT.Client, message MQTT.Message) {
 		PublishClientMessage(client, SharedSubscriptionConfig.RepostRootTopic+"ble/temperature/"+bleTemp.Location, bleTemp.ToJSON(), true)
 	}
 	if SharedSubscriptionConfig.InfluxEnabled {
-		log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-			SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-		if SharedSubscriptionConfig.BLELogEn {
-			log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-		}
-		writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := bleTemp.ToInfluxPoint()
-		err := writeAPI.WritePoint(context.Background(), p)
+		err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Warn().Msgf("Error writing to influx: %v", err.Error())
 		}

--- a/internal/BLETempHandler.go
+++ b/internal/BLETempHandler.go
@@ -73,16 +73,12 @@ func handleBLETemperatureMessage(client MQTT.Client, message MQTT.Message) {
 			log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		}
-		// Sharing a client across threads did not seem to work
-		// So will create a client each time for now
-		client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-		writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+		writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := bleTemp.ToInfluxPoint()
 		err := writeAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Warn().Msgf("Error writing to influx: %v", err.Error())
 		}
-		client.Close()
 		log.Trace().Msg("Wrote Point")
 		if SharedSubscriptionConfig.BLELogEn {
 			log.Debug().Msg("Wrote Point")

--- a/internal/BLETempHandler.go
+++ b/internal/BLETempHandler.go
@@ -75,7 +75,7 @@ func handleBLETemperatureMessage(client MQTT.Client, message MQTT.Message) {
 		}
 		// Sharing a client across threads did not seem to work
 		// So will create a client each time for now
-		client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+		client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 		writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := bleTemp.ToInfluxPoint()
 		err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/ESPStatusHandler.go
+++ b/internal/ESPStatusHandler.go
@@ -84,7 +84,7 @@ func handleESPStatusMessage(client MQTT.Client, message MQTT.Message) {
 		}
 		// Sharing a client across threads did not seem to work
 		// So will create a client each time for now
-		client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+		client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 		writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := espStatus.ToInfluxPoint()
 		err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/ESPStatusHandler.go
+++ b/internal/ESPStatusHandler.go
@@ -76,15 +76,8 @@ func handleESPStatusMessage(client MQTT.Client, message MQTT.Message) {
 		PublishClientMessage(client, SharedSubscriptionConfig.RepostRootTopic+"esp/status/"+espStatus.Location, espStatus.ToJSON(), true)
 	}
 	if SharedSubscriptionConfig.InfluxEnabled {
-		log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-			SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-		if SharedSubscriptionConfig.ESPLogEn {
-			log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-		}
-		writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := espStatus.ToInfluxPoint()
-		err := writeAPI.WritePoint(context.Background(), p)
+		err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Warn().Msgf("Error writing to influx: %v", err.Error())
 		}

--- a/internal/ESPStatusHandler.go
+++ b/internal/ESPStatusHandler.go
@@ -82,16 +82,12 @@ func handleESPStatusMessage(client MQTT.Client, message MQTT.Message) {
 			log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		}
-		// Sharing a client across threads did not seem to work
-		// So will create a client each time for now
-		client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-		writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+		writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := espStatus.ToInfluxPoint()
 		err := writeAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Warn().Msgf("Error writing to influx: %v", err.Error())
 		}
-		client.Close()
 		log.Trace().Msg("Wrote Point")
 		if SharedSubscriptionConfig.ESPLogEn {
 			log.Debug().Msg("Wrote Point")

--- a/internal/GNSSHandler.go
+++ b/internal/GNSSHandler.go
@@ -103,15 +103,8 @@ func handleGNSSMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/gnss/"+gnss.Source+"/"+measurement, gnss.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.GNSSLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := gnss.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}

--- a/internal/GNSSHandler.go
+++ b/internal/GNSSHandler.go
@@ -111,7 +111,7 @@ func handleGNSSMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := gnss.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/GNSSHandler.go
+++ b/internal/GNSSHandler.go
@@ -109,16 +109,12 @@ func handleGNSSMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := gnss.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.GNSSLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/NavigationHandler.go
+++ b/internal/NavigationHandler.go
@@ -145,16 +145,12 @@ func handleNavigationMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := nav.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.NavLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/NavigationHandler.go
+++ b/internal/NavigationHandler.go
@@ -139,15 +139,8 @@ func handleNavigationMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/navigation/"+nav.Source+"/"+measurement, nav.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.NavLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := nav.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}

--- a/internal/NavigationHandler.go
+++ b/internal/NavigationHandler.go
@@ -147,7 +147,7 @@ func handleNavigationMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := nav.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/OutsideHandler.go
+++ b/internal/OutsideHandler.go
@@ -86,15 +86,8 @@ func handleOutsideMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/environment/outside/"+out.Source+"/"+measurement, out.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.OutsideLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := out.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}

--- a/internal/OutsideHandler.go
+++ b/internal/OutsideHandler.go
@@ -94,7 +94,7 @@ func handleOutsideMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := out.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/OutsideHandler.go
+++ b/internal/OutsideHandler.go
@@ -92,16 +92,12 @@ func handleOutsideMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := out.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.OutsideLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/PHYTempHandler.go
+++ b/internal/PHYTempHandler.go
@@ -71,16 +71,12 @@ func handlePHYTemperatureMessage(client MQTT.Client, message MQTT.Message) {
 			log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		}
-		// Sharing a client across threads did not seem to work
-		// So will create a client each time for now
-		client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-		writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+		writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := phyTemp.ToInfluxPoint()
 		err := writeAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Warn().Msgf("Error writing to influx: %v", err.Error())
 		}
-		client.Close()
 		log.Trace().Msg("Wrote Point")
 		if SharedSubscriptionConfig.PHYLogEn {
 			log.Debug().Msg("Wrote Point")

--- a/internal/PHYTempHandler.go
+++ b/internal/PHYTempHandler.go
@@ -65,15 +65,8 @@ func handlePHYTemperatureMessage(client MQTT.Client, message MQTT.Message) {
 		PublishClientMessage(client, SharedSubscriptionConfig.RepostRootTopic+"rtd/temperature/"+phyTemp.Location, phyTemp.ToJSON(), true)
 	}
 	if SharedSubscriptionConfig.InfluxEnabled {
-		log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-			SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-		if SharedSubscriptionConfig.PHYLogEn {
-			log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-		}
-		writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := phyTemp.ToInfluxPoint()
-		err := writeAPI.WritePoint(context.Background(), p)
+		err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 		if err != nil {
 			log.Warn().Msgf("Error writing to influx: %v", err.Error())
 		}

--- a/internal/PHYTempHandler.go
+++ b/internal/PHYTempHandler.go
@@ -73,7 +73,7 @@ func handlePHYTemperatureMessage(client MQTT.Client, message MQTT.Message) {
 		}
 		// Sharing a client across threads did not seem to work
 		// So will create a client each time for now
-		client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+		client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 		writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 		p := phyTemp.ToInfluxPoint()
 		err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/PropulsionHandler.go
+++ b/internal/PropulsionHandler.go
@@ -128,15 +128,8 @@ func handlePropulsionMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/propulsion/"+prop.Source+"/"+measurement, prop.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.PropLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := prop.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}

--- a/internal/PropulsionHandler.go
+++ b/internal/PropulsionHandler.go
@@ -134,16 +134,12 @@ func handlePropulsionMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := prop.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.PropLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/PropulsionHandler.go
+++ b/internal/PropulsionHandler.go
@@ -136,7 +136,7 @@ func handlePropulsionMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := prop.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/SteeringHandler.go
+++ b/internal/SteeringHandler.go
@@ -102,7 +102,7 @@ func handleSteeringMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := steer.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/SteeringHandler.go
+++ b/internal/SteeringHandler.go
@@ -94,15 +94,8 @@ func handleSteeringMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/steering/"+steer.Source+"/"+measurement, steer.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.SteerLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := steer.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}

--- a/internal/SteeringHandler.go
+++ b/internal/SteeringHandler.go
@@ -100,16 +100,12 @@ func handleSteeringMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := steer.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.SteerLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/SubscriptionManager.go
+++ b/internal/SubscriptionManager.go
@@ -25,12 +25,14 @@ import (
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/rs/zerolog/log"
 )
 
 var SharedSubscriptionConfig *SubscriptionConfig
 var ISOTimeLayout string = "2006-01-02T15:04:05.000Z"
 var SharedInfluxHttpClient *http.Client
+var SharedInfluxClient influxdb2.Client
 
 func HandleSubscriptions(subscribeconf SubscriptionConfig) {
 	SharedSubscriptionConfig = &subscribeconf
@@ -51,7 +53,9 @@ func HandleSubscriptions(subscribeconf SubscriptionConfig) {
 			IdleConnTimeout:     90 * time.Second,
 		},
 	}
-	_ = SharedInfluxHttpClient
+	SharedInfluxClient := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
+	_ = SharedInfluxClient
+	defer SharedInfluxClient.Close()
 	log.Info().Msgf("Will subscribe on server %v", SharedSubscriptionConfig.Host)
 	mqttOpts := MQTT.NewClientOptions()
 	mqttOpts.AddBroker(SharedSubscriptionConfig.Host)

--- a/internal/SubscriptionManager.go
+++ b/internal/SubscriptionManager.go
@@ -51,6 +51,7 @@ func HandleSubscriptions(subscribeconf SubscriptionConfig) {
 			IdleConnTimeout:     90 * time.Second,
 		},
 	}
+	_ = SharedInfluxHttpClient
 	log.Info().Msgf("Will subscribe on server %v", SharedSubscriptionConfig.Host)
 	mqttOpts := MQTT.NewClientOptions()
 	mqttOpts.AddBroker(SharedSubscriptionConfig.Host)

--- a/internal/SubscriptionManager.go
+++ b/internal/SubscriptionManager.go
@@ -55,7 +55,6 @@ func HandleSubscriptions(subscribeconf SubscriptionConfig) {
 	}
 	SharedInfluxClient := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 	_ = SharedInfluxClient
-	defer SharedInfluxClient.Close()
 	log.Info().Msgf("Will subscribe on server %v", SharedSubscriptionConfig.Host)
 	mqttOpts := MQTT.NewClientOptions()
 	mqttOpts.AddBroker(SharedSubscriptionConfig.Host)
@@ -95,6 +94,7 @@ func HandleSubscriptions(subscribeconf SubscriptionConfig) {
 		log.Warn().Msgf("Error Connecting to host: %v", token.Error())
 		return
 	}
+	defer SharedInfluxClient.Close()
 }
 
 func addSubscription(topic string, target MQTT.MessageHandler, mqttClient MQTT.Client) {

--- a/internal/WaterHandler.go
+++ b/internal/WaterHandler.go
@@ -94,7 +94,7 @@ func handleWaterMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := water.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/WaterHandler.go
+++ b/internal/WaterHandler.go
@@ -92,16 +92,12 @@ func handleWaterMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := water.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.WaterLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/WaterHandler.go
+++ b/internal/WaterHandler.go
@@ -86,15 +86,8 @@ func handleWaterMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/environment/water/"+water.Source+"/"+measurement, water.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.WaterLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := water.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}

--- a/internal/WindHandler.go
+++ b/internal/WindHandler.go
@@ -96,16 +96,12 @@ func handleWindMessage(client MQTT.Client, message MQTT.Message) {
 				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
 					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			}
-			// Sharing a client across threads did not seem to work
-			// So will create a client each time for now
-			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
-			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
+			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := wind.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}
-			client.Close()
 			log.Trace().Msg("Wrote Point")
 			if SharedSubscriptionConfig.WindLogEn {
 				log.Debug().Msg("Wrote Point")

--- a/internal/WindHandler.go
+++ b/internal/WindHandler.go
@@ -98,7 +98,7 @@ func handleWindMessage(client MQTT.Client, message MQTT.Message) {
 			}
 			// Sharing a client across threads did not seem to work
 			// So will create a client each time for now
-			client := influxdb2.NewClient(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken)
+			client := influxdb2.NewClientWithOptions(SharedSubscriptionConfig.InfluxUrl, SharedSubscriptionConfig.InfluxToken, influxdb2.DefaultOptions().SetHTTPClient(SharedInfluxHttpClient))
 			writeAPI := client.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := wind.ToInfluxPoint()
 			err := writeAPI.WritePoint(context.Background(), p)

--- a/internal/WindHandler.go
+++ b/internal/WindHandler.go
@@ -90,15 +90,8 @@ func handleWindMessage(client MQTT.Client, message MQTT.Message) {
 				SharedSubscriptionConfig.RepostRootTopic+"vessel/environment/wind/"+wind.Source+"/"+measurement, wind.ToJSON(), true)
 		}
 		if SharedSubscriptionConfig.InfluxEnabled {
-			log.Trace().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-				SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			if SharedSubscriptionConfig.WindLogEn {
-				log.Debug().Msgf("InfluxDB is enabled. URL: %v Org: %v Bucket:%v", SharedSubscriptionConfig.InfluxUrl,
-					SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
-			}
-			writeAPI := SharedInfluxClient.WriteAPIBlocking(SharedSubscriptionConfig.InfluxOrg, SharedSubscriptionConfig.InfluxBucket)
 			p := wind.ToInfluxPoint()
-			err := writeAPI.WritePoint(context.Background(), p)
+			err := SharedInfluxWriteAPI.WritePoint(context.Background(), p)
 			if err != nil {
 				log.Warn().Msgf("Error writing to influx: %v", err.Error())
 			}


### PR DESCRIPTION
Reopening connections with the influx client results in spamming DNS server which in turn results in errors resolving the server.  Reusing the underlying http client will then use cached dns results.